### PR TITLE
Allow to set syslog facility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,8 +30,9 @@ msmtp_default_account: yandex
 msmtp_domain:          yandex.com
 
 ## Logging (Select A) "syslog" or B) "file" logging or C) "no" log
-msmtp_log:       file
-msmtp_logfile:   ~/.msmtp.log
+msmtp_log:             file
+msmtp_syslog_facility: ""
+msmtp_logfile:         ~/.msmtp.log
 
 ## Aliases mail account ( only msmtp_alias_default is required the rest is optional )
 msmtp_alias_default: emailer.tests@yandex.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,8 @@ msmtp_domain:          yandex.com
 
 ## Logging (Select A) "syslog" or B) "file" logging or C) "no" log
 msmtp_log:             file
-msmtp_syslog_facility: ""
++## If using `syslog`, can be one of 'LOG_USER', 'LOG_MAIL', 'LOG_LOCAL0', …, 'LOG_LOCAL7'.
++msmtp_syslog_facility: "LOG_USER"
 msmtp_logfile:         ~/.msmtp.log
 
 ## Aliases mail account ( only msmtp_alias_default is required the rest is optional )

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,8 +31,8 @@ msmtp_domain:          yandex.com
 
 ## Logging (Select A) "syslog" or B) "file" logging or C) "no" log
 msmtp_log:             file
-+## If using `syslog`, can be one of 'LOG_USER', 'LOG_MAIL', 'LOG_LOCAL0', …, 'LOG_LOCAL7'.
-+msmtp_syslog_facility: "LOG_USER"
+## If using `syslog`, can be one of 'LOG_USER', 'LOG_MAIL', 'LOG_LOCAL0', …, 'LOG_LOCAL7'.
+msmtp_syslog_facility: "LOG_USER"
 msmtp_logfile:         ~/.msmtp.log
 
 ## Aliases mail account ( only msmtp_alias_default is required the rest is optional )

--- a/templates/msmtprc.j2
+++ b/templates/msmtprc.j2
@@ -14,7 +14,11 @@ tls_trust_file /etc/ssl/certs/ca-certificates.crt
 # Logging
 {% if msmtp_log is defined %}
 {% if msmtp_log == "syslog" %}
+{% if msmtp_syslog_facility %}
+syslog {{msmtp_syslog_facility}}
+{% else %}
 syslog on
+{% endif %}
 {% elif msmtp_log == "file" and msmtp_logfile is defined %}
 logfile  {{msmtp_logfile}}
 {% endif %}

--- a/templates/msmtprc.j2
+++ b/templates/msmtprc.j2
@@ -14,11 +14,7 @@ tls_trust_file /etc/ssl/certs/ca-certificates.crt
 # Logging
 {% if msmtp_log is defined %}
 {% if msmtp_log == "syslog" %}
-{% if msmtp_syslog_facility %}
-syslog {{msmtp_syslog_facility}}
-{% else %}
-syslog on
-{% endif %}
+syslog {{ msmtp_syslog_facility }}
 {% elif msmtp_log == "file" and msmtp_logfile is defined %}
 logfile  {{msmtp_logfile}}
 {% endif %}


### PR DESCRIPTION
Msmtp allows to configure the syslog facility by setting `syslog` to one of `LOG_USER, LOG_MAIL, LOG_LOCAL0, ..., LOG_LOCAL7`. This patch enables this functionality to the Ansible role.