### PR TITLE
Make permissions on /etc/msmtprc configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ This ansible role deploys msmtp as a mailer for Debian, Ubuntu, Arch & Alpine Li
 
          `msmtp_alias_cron : cron@example.com`
 
+  - Configuration file permissions
+     - *msmtprc_owner:* owner of /etc/msmtprc, default `root`
+
+         `msmtprc_owner : root`
+
+     - *msmtprc_group:* group of /etc/msmtprc, default `root`
+
+         `msmtprc_group : root`
+
+     - *msmtprc_mode:* group of /etc/msmtprc, default `0644`
+
+         `msmtprc_mode : 0644`
+
 ## Configure
 You can configure your variables in ansible with one of the following
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,3 +44,8 @@ msmtp_test_mail_recipient: tester@example.org
 
 ## This will remove most other mail transfer agents such as postfix, exim,...!
 msmtp_remove_mtas: no
+
+## Permissions for the configuration file
+msmtprc_owner: root
+msmtprc_group: root
+msmtprc_mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,9 +75,9 @@
   template:
      src: msmtprc.j2
      dest: /etc/msmtprc
-     owner: root
-     group: root
-     mode: 0644
+     owner: "{{ msmtprc_owner }}"
+     group: "{{ msmtprc_group }}"
+     mode: "{{ msmtprc_mode }}"
   tags: mail
   notify: test mail
 


### PR DESCRIPTION
This pull request makes the ownership and permissions of /etc/msmtprc configurable. I want this so that I can make the group of the file `msmtp` and the permissions `0640`, so random processes can't get at my SMTP credentials.