### PR TITLE
add support for per account tls_starttls configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This ansible role deploys msmtp as a mailer for Debian, Ubuntu, Arch & Alpine Li
         from:      admin@example.org
         user:      myuser@example.org
         password:  plain-text-password2
+        tls_starttls: "off"
       ```
   - *msmtp_default_account:* Default smtp account to use
 

--- a/templates/msmtprc.j2
+++ b/templates/msmtprc.j2
@@ -37,6 +37,9 @@ auth     {{msmtp_account.auth}}
 from     {{msmtp_account.from}}
 user     {{msmtp_account.user}}
 password {{msmtp_account.password}}
+{% if msmtp_account.tls_starttls is defined %}
+tls_starttls {{msmtp_account.tls_starttls}}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Allows to override default configuration.