### PR TITLE
added configuration option for starttls

### DIFF
--- a/templates/msmtprc.j2
+++ b/templates/msmtprc.j2
@@ -4,7 +4,11 @@
 defaults
 auth   on
 tls    on
+{% if msmtp_tls_starttls is defined %}
+tls_starttls {{msmtp_tls_starttls}}
+{% else %}
 tls_starttls   on
+{% endif %}
 {% if msmtp_tls_trust_file is defined %}
 tls_trust_file {{msmtp_tls_trust_file}}
 {% else %}


### PR DESCRIPTION
In some edge cases `starttls` might not work on a server. It would be nice to add an configuration option. It seems to me, that no documentation is needed, as it should just cover edge cases.