### PR TITLE
Add msmtp_set_from_header option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ This ansible role deploys msmtp as a mailer for Debian, Ubuntu, Arch & Alpine Li
 
          `msmtprc_mode : 0644`
 
+  - `From` header
+     - *msmtp_set_from_header:* value of `set_from_header` configuration option, default off - set to `on` to always add (or override any existing) From header, `off` to never add (or alter an existing) From header, or `auto` to add a From header if one is not present.
+
+         `msmtp_set_from_header : off`
+
 ## Configure
 You can configure your variables in ansible with one of the following
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,12 @@ msmtp_test_mail_recipient: tester@example.org
 ## This will remove most other mail transfer agents such as postfix, exim,...!
 msmtp_remove_mtas: no
 
+## From header
+# - `on` to always add (or override any existing) From header
+# - `off` to never add (or alter an existing) From header
+# - `auto` to add a From header if one is not present
+msmtp_set_from_header: off
+
 ## Permissions for the configuration file
 msmtprc_owner: root
 msmtprc_group: root

--- a/templates/msmtprc.j2
+++ b/templates/msmtprc.j2
@@ -26,10 +26,19 @@ logfile  {{msmtp_logfile}}
 
 # default is localhost. Use domain part of your email address or FQDN of host.
 domain {{msmtp_domain}}
-# default is off. When on, an envelope-from address of the form user@domain will be generated.
-auto_from off
+
 # The default is to remove BCC headers.
 # remove_bcc_headers  on|off
+
+{% if (msmtp_set_from_header is defined) and (msmtp_set_from_header != '') %}
+{% if msmtp_set_from_header == true %}
+set_from_header on
+{% elif msmtp_set_from_header == false %}
+set_from_header off
+{% else %}
+set_from_header {{msmtp_set_from_header}}
+{% endif %}
+{% endif %}
 
 {% if msmtp_accounts is defined %}
 {% for msmtp_account in msmtp_accounts %}


### PR DESCRIPTION
Instead of always setting the now-deprecated option `auto_from` to `off`, this PR switches to using the `set_from_header` option, and allows controlling its value. It adds a default value of `off` for `set_from_header`, which should behave the same as the previous `auto_from off`.