### PR TITLE
Add support for per account tls configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ This ansible role deploys msmtp as a mailer for Debian, Ubuntu, Arch & Alpine Li
         user:      myuser@example.org
         password:  plain-text-password2
         tls_starttls: "off"
+      - account:   local
+        host:      127.0.0.1
+        port:      25
+        auth:      "plain"
+        from:      admin@example.com
+        user:      myuser@example.com
+        password:  plain-text-password3
+        tls:       "off"
+        tls_starttls: "off"
       ```
   - *msmtp_default_account:* Default smtp account to use
 

--- a/templates/msmtprc.j2
+++ b/templates/msmtprc.j2
@@ -41,6 +41,9 @@ auth     {{msmtp_account.auth}}
 from     {{msmtp_account.from}}
 user     {{msmtp_account.user}}
 password {{msmtp_account.password}}
+{% if msmtp_account.tls is defined %}
+tls      {{msmtp_account.tls}}
+{% endif %}
 {% if msmtp_account.tls_starttls is defined %}
 tls_starttls {{msmtp_account.tls_starttls}}
 {% endif %}


### PR DESCRIPTION
I added the option because I wanted to turn off TLS when using the SMTP server on the localhost.